### PR TITLE
Update upstream parity

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ ewasm_api = { git = "https://github.com/ewasm/ewasm-rust-api", tag = "0.4.0" }
 #ewasm_api = { path = "../ewasm-rust-api" }
 evm = { path = "parity-ethereum/ethcore/evm" }
 vm = { path = "parity-ethereum/ethcore/vm" }
-ethereum-types = "0.3"
+ethereum-types = "0.4"
 parity-bytes = { git = "https://github.com/paritytech/parity-common" }
 
 [lib]

--- a/build.sh
+++ b/build.sh
@@ -4,17 +4,17 @@ set -e
 
 # build interpreter
 cargo build --release --target wasm32-unknown-unknown
-echo "Code size after compilation: $(stat -f%z target/wasm32-unknown-unknown/release/runevm.wasm)"
+echo "Code size after compilation: $(wc -c < target/wasm32-unknown-unknown/release/runevm.wasm)"
 
 # strip code
-wasm-gc target/wasm32-unknown-unknown/release/runevm.wasm
-echo "Code size after stripping: $(stat -f%z target/wasm32-unknown-unknown/release/runevm.wasm)"
+chisel target/wasm32-unknown-unknown/release/runevm.wasm target/wasm32-unknown-unknown/release/runevm.wasm
+echo "Code size after stripping: $(wc -c < target/wasm32-unknown-unknown/release/runevm.wasm)"
 
 # build deployer
-./wat2wasm -o target/deployer.wasm src/deployer.wast
+wat2wasm -o target/deployer.wasm src/deployer.wast
 
 # calculate size
-size=$(stat -f%z target/wasm32-unknown-unknown/release/runevm.wasm)
+size=$(wc -c < target/wasm32-unknown-unknown/release/runevm.wasm)
 # store the file size as a 32-bit little endian number
 printf "0: %.8x" $size | sed -E 's/0: (..)(..)(..)(..)/0: \4\3\2\1/' | xxd -r -g0 >target/le32size.bin
 echo "Interpreter code size: $size"
@@ -22,4 +22,4 @@ echo "Interpreter code size: $size"
 # create deployment code
 cat target/deployer.wasm target/wasm32-unknown-unknown/release/runevm.wasm target/le32size.bin >target/runevm.wasm
 echo "Built evm2wasm compatible version as target/runevm.wasm"
-echo "Total size: $(stat -f%z target/runevm.wasm)"
+echo "Total size: $(wc -c < target/runevm.wasm)"


### PR DESCRIPTION
This PR updates the `parity-ethereum` to v2.3.3, and fixes the breaking api changes that have happened. Build doesn't fail anymore, but I didn't know how to test it!