### PR TITLE
Update ewasm_api to 0.7

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ description = "EVM interpreter compatible with the evm2wasm interface"
 publish = false
 
 [dependencies]
-ewasm_api = "0.4"
+ewasm_api = "0.7"
 evm = { path = "parity-ethereum/ethcore/evm" }
 vm = { path = "parity-ethereum/ethcore/vm" }
 ethereum-types = "0.4"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -161,7 +161,7 @@ impl vm::Ext for EwasmExt {
                 },
                 &data,
             ),
-            _ => panic!(),
+            _ => ewasm_api::abort(),
         };
 
         // FIXME: might not be good enough
@@ -189,7 +189,7 @@ impl vm::Ext for EwasmExt {
                     ReturnData::new(ret, 0, ret_len),
                 ))
             }
-            ewasm_api::CallResult::Unknown => panic!(),
+            ewasm_api::CallResult::Unknown => ewasm_api::abort(),
         }
 
         // FIXME: no way to know if it ran out of gas? Handle it properly.
@@ -351,14 +351,8 @@ pub extern "C" fn main() {
             }
         }
         // FIXME: not sure what this state means
-        Ok(Err(err)) => {
-            // panic will trigger an unreachable instruction which in turn is a regular failure
-            panic!()
-        }
+        Ok(Err(err)) => ewasm_api::abort(),
         // FIXME: add support for pushing the error message as revert data
-        Err(err) => {
-            // panic will trigger an unreachable instruction which in turn is a regular failure
-            panic!()
-        }
+        Err(err) => ewasm_api::abort(),
     }
 }


### PR DESCRIPTION
- The major change was custom types introduced by ewasm_api which needed conversion. 
- Another was `CallResult::Unknown`, in which case the contract should panic (https://github.com/ewasm/ewasm-rust-api/pull/34).

Fixes #13